### PR TITLE
fix: correctly display IGN in cards

### DIFF
--- a/CharacterCards/pom.xml
+++ b/CharacterCards/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>me.ShermansWorld</groupId>
 	<artifactId>CharacterCards</artifactId>
-	<version>2.2.4</version>
+	<version>2.2.5</version>
 	<packaging>jar</packaging>
 	<name>CharacterCards</name>
 	<url>http://maven.apache.org</url>

--- a/CharacterCards/src/main/java/me/ShermansWorld/CharacterCards/Cards.java
+++ b/CharacterCards/src/main/java/me/ShermansWorld/CharacterCards/Cards.java
@@ -26,7 +26,7 @@ public class Cards {
 				msg = msg.replaceAll("@PLAYER", player.getName());
 			int titleLen = msg.length() + 22;
 			player.sendMessage(Helper.color("&8&l&m-----------&7[&3" + msg + "&7]&8&l&m-----------"));
-			player.sendMessage(Helper.color("&3IGN &8- &b" + yamlConfiguration.get("IGN")));
+			player.sendMessage(Helper.color("&3IGN &8- &b" + player.getName());
 			if (!yamlConfiguration.getString("Name").isEmpty()) {
 				player.sendMessage(
 						Helper.color("&3" + lang.getString("Cards.Name") + " &8- &b" + yamlConfiguration.get("Name")));
@@ -80,7 +80,7 @@ public class Cards {
 					msg = msg.replaceAll("@PLAYER", target.getName());
 				int titleLen = msg.length() + 22;
 				player.sendMessage(Helper.color("&8&l&m-----------&7[&3" + msg + "&7]&8&l&m-----------"));
-				player.sendMessage(Helper.color("&3IGN &8- &b" + yamlConfiguration.get("IGN")));
+				player.sendMessage(Helper.color("&3IGN &8- &b" + target.getName()));
 				if (!yamlConfiguration.getString("Name").isEmpty()) {
 					player.sendMessage(Helper
 							.color("&3" + lang.getString("Cards.Name") + " &8- &b" + yamlConfiguration.get("Name")));
@@ -137,7 +137,7 @@ public class Cards {
 				msg = msg.replaceAll("@PLAYER", target.getName());
 			int titleLen = msg.length() + 22;
 			player.sendMessage(Helper.color("&8&l&m-----------&7[&3" + msg + "&7]&8&l&m-----------"));
-			player.sendMessage(Helper.color("&3IGN &8- &b" + yamlConfiguration.get("IGN")));
+			player.sendMessage(Helper.color("&3IGN &8- &b" + target.getName()));
 			if (!yamlConfiguration.getString("Name").isEmpty()) {
 				player.sendMessage(
 						Helper.color("&3" + lang.getString("Cards.Name") + " &8- &b" + yamlConfiguration.get("Name")));

--- a/CharacterCards/src/main/java/me/ShermansWorld/CharacterCards/listeners/MakeFileonJoin.java
+++ b/CharacterCards/src/main/java/me/ShermansWorld/CharacterCards/listeners/MakeFileonJoin.java
@@ -14,14 +14,9 @@ public class MakeFileonJoin implements Listener {
     File f = new File("plugins" + File.separator + "CharacterCards" + File.separator + "users" + File.separator + e.getPlayer().getUniqueId() + ".yml");
     YamlConfiguration yamlConfiguration = YamlConfiguration.loadConfiguration(f);
     
-    if (! (e.getPlayer().getName().equals(yamlConfiguration.get("IGN")))) { // update IGN if player changes their username 
-    	yamlConfiguration.set("IGN", e.getPlayer().getName());
-    }
-    
     if (!f.exists())
       try {
         f.createNewFile();
-        yamlConfiguration.set("IGN", e.getPlayer().getName());
         yamlConfiguration.set("Name", "");
         yamlConfiguration.set("Gender", "");
         yamlConfiguration.set("Age", "");

--- a/CharacterCards/src/main/resources/plugin.yml
+++ b/CharacterCards/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: CharacterCards
 main: me.ShermansWorld.CharacterCards.CharacterCards
-version: 2.2.4
+version: 2.2.5
 api-version: 1.19
 author: ShermansWorld
 softdepend: [Towny, MythicalRaces, Konquest, Magic, PlaceholderAPI]


### PR DESCRIPTION
Correctly displays the targets username in a character card, using `player#getName` rather than a stored value. [This line](https://github.com/ShermansWorld/CharacterCards/blob/e84d8d970c18e6b43bd12cf3c507b770264619d7/CharacterCards/src/main/java/me/ShermansWorld/CharacterCards/listeners/MakeFileonJoin.java#L24) could likely also be removed - as that stored value should no longer be needed, but I'll leave that decision up to you.

I'm assuming the issue is caused by [this](https://github.com/ShermansWorld/CharacterCards/blob/e84d8d970c18e6b43bd12cf3c507b770264619d7/CharacterCards/src/main/java/me/ShermansWorld/CharacterCards/listeners/MakeFileonJoin.java#L18) not firing correctly for whatever reason. Regardless, it's not necessary to store the player's username in a file as that is accessible through the Spigot API.